### PR TITLE
package.json trailing comma issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "main": "./lib/docpad.tsplugin.ts",
   "dependencies": {
-    "lax-typescript": "git://github.com/perpetual-motion/lax-typescript.git",
+    "lax-typescript": "git://github.com/perpetual-motion/lax-typescript.git"
   }
 }


### PR DESCRIPTION
On current versions of NPM the trailing comma on key-value lax-typescript is considered error and privents npm install of all dependent packages.